### PR TITLE
change local settings of webpack to fix error 'Unexpected token"

### DIFF
--- a/django/webpack.local.config.js
+++ b/django/webpack.local.config.js
@@ -11,7 +11,15 @@ config.plugins = config.plugins.concat([
 ])
 
 config.module.loaders.push(
-  { test: /\.jsx?$/, exclude: /node_modules/, loaders: ['react-hot', 'babel'] }
+  { 
+    test: /\.jsx?$/,         // Match both .js and .jsx files
+    exclude: /node_modules/, 
+    loader: "babel", 
+    query:
+      {
+        presets:['react']
+      }
+  }
 )
 
 module.exports = config


### PR DESCRIPTION
I have had this error when running weback at the end of STEP 3.

![screen shot 2017-10-13 at 12 23 52 pm](https://user-images.githubusercontent.com/9556790/31542192-65e7b7d2-b011-11e7-8889-704bd6651681.png)

I changed the webpack.local.config.js by following this post: https://stackoverflow.com/questions/33460420/babel-loader-jsx-syntaxerror-unexpected-token?answertab=votes#tab-top