### PR TITLE
Add Access-Control-Allow-Origin header for webpack dev server

### DIFF
--- a/django/server.js
+++ b/django/server.js
@@ -6,6 +6,7 @@ new WebpackDevServer(webpack(config), {
   publicPath: config.output.publicPath,
   hot: true,
   inline: true,
+  headers: { "Access-Control-Allow-Origin": "*" },
   historyApiFallback: true,
 }).listen(3000, config.ip, function (err, result) {
   if (err) {


### PR DESCRIPTION
Hot Reloading functionality wasn't working due to CORS error on webpack dev server on Google Chrome. It was not serving bundles whenever I change something on react component.